### PR TITLE
Fix build with glibc >= 2.27

### DIFF
--- a/src/offset.c
+++ b/src/offset.c
@@ -62,7 +62,7 @@ offset_optimal (gint    *resultat,
                 gint     channels, guchar **filled,
                 gboolean tileable) {
   gint x_i, y_i;
-  float best_difference = HUGE, tmp_difference;
+  float best_difference = INFINITY, tmp_difference;
 
   for (x_i = x_patch_posn_min; x_i < x_patch_posn_max; x_i++) {
     for (y_i = y_patch_posn_min; y_i < y_patch_posn_max; y_i++) {


### PR DESCRIPTION
Patch from Debian.


Description: fix build with glibc >= 2.27.
             glibc >= 2.27 has removed SVID support, and the HUGE constant as
             part of it. Replace it with INFINITY, which is more suitable in
             that case.
Author: Aurelien Jarno <aurel32@debian.org>
Last-Update: 2018-02-11